### PR TITLE
committing-Panel-listener-changes

### DIFF
--- a/src/Board.java
+++ b/src/Board.java
@@ -1,7 +1,8 @@
 import java.awt.*;
+import java.io.Serializable;
 import java.util.HashMap;
 
-public class Board implements Drawable {
+public class Board implements Drawable, Serializable {
     private Lane toDo;
     private Lane inProgress;
     private Lane completed;
@@ -64,9 +65,20 @@ public class Board implements Drawable {
 
         g.setColor(Color.LIGHT_GRAY);
         g.fillRect(0, 0, width, height);
+
+	//draw Lanes
         toDo.draw(g);
         inProgress.draw(g);
         completed.draw(g);
-
+	//draw Panels
+	for(Panel p : toDo.getPanels()) {
+	    p.draw(g);
+	}
+	for(Panel p : inProgress.getPanels()) {
+	    p.draw(g);
+	}
+	for(Panel p : completed.getPanels()) {
+	    p.draw(g);
+	}
     }
 }

--- a/src/Lane.java
+++ b/src/Lane.java
@@ -1,9 +1,10 @@
 import java.awt.*;
+import javax.swing.*;
 import java.util.ArrayList;
 import java.util.HashSet;
 
 
-public class Lane implements Drawable {
+public class Lane extends JComponent implements Drawable {
 
     /**
      * Used for keeping track of all panels used by all of the Lane instances.
@@ -130,9 +131,5 @@ public class Lane implements Drawable {
         int fontY = g.getFontMetrics(font).getAscent();
         g.setFont(font);
         g.drawString(title, xCoord + (xWidth - fontX) / 2, yCoord + (margin / 2 + fontY) / 2);
-
-        for (Panel p : panels) {
-            p.draw(g);
-        }
     }
 }

--- a/src/ObservableHelper.java
+++ b/src/ObservableHelper.java
@@ -1,4 +1,5 @@
 import java.util.Observable;
+import java.io.Serializable;
 
 
 /**
@@ -9,7 +10,7 @@ import java.util.Observable;
  * The Oracle docs for the Observable class were used during implementation.
  * https://docs.oracle.com/javase/8/docs/api/index.html?java/util/Observer.html
  */
-public class ObservableHelper extends Observable {
+public class ObservableHelper extends Observable implements Serializable {
     public ObservableHelper() {
     }
 


### PR DESCRIPTION
- LanePanels array of JLabels in Main class no longer have mouseListeners or mouseMotionListeners
- Every panel created now has a mouseListener and mouseMotionListener, and these are used to move Panels and keep track of mouse motions in Lane areas
- Lane extends JComponent
- Board and Main implement Serializable
